### PR TITLE
created the index of documentation

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,0 +1,26 @@
+# YaCy documentation
+
+## Basics
+* [Download and installation](download_installation.md) - guide for unix, windows and macos
+* [FAQ](faq.md) - Frequently asked questions 
+
+## Operation
+* [Headless - YaCy on a Remote Server](operation/headless.md)
+* [Shrink Debian by removing all graphical features to turn it into a headless server](operation/shrink.md)
+* [Set a static IP to a debian server](operation/staticip.md)
+
+## Developers
+* [How to contribute](contribute.md)
+* [Crawler API](api/crawler.md)
+* [javadoc](https://yacy.net/api/javadoc/) - generated documentation for YaCy's java source code
+
+
+## Old and obsolete
+The original YaCy wiki is closed now (no new registration or editing) and
+will be abandoned in future, but still contains valuable information.  You
+can help the community by transfering the usable information to [yacy github
+documentation](https://github.com/yacy/yacy_net_homepage/) from which this
+page is being generated.  [See how.](contribute.md)
+
+* [yacy wiki](https://wiki.yacy.net/index.php/En:Start) - please help
+* [developers wiki](https://wiki.yacy.net/index.php/Dev:Start) - please help


### PR DESCRIPTION
Since the documentation is fragmented and some pages are not referenced from anywhere (or cluttered deep-inside other documents), I created this index. Later it could be included as "Docs" in the top menu. 

Because a lot of information is included in legacy wiki, links are included in "Old and obsolete" section, asking community for help. 