### PR TITLE
added a release.yacy.net download button

### DIFF
--- a/docs/download_installation.md
+++ b/docs/download_installation.md
@@ -25,6 +25,7 @@ If you don't hava Docker installed, get it from [https://docs.docker.com/get-doc
 * <a class="btn btn-success btn" href="https://download.yacy.net/yacy_v1.924_20201214_10042.exe" role="button">Download YaCy for Windows</a> from [https://download.yacy.net/yacy_v1.924_20201214_10042.exe](https://download.yacy.net/yacy_v1.924_20201214_10042.exe)
 * <a class="btn btn-success btn" href="https://download.yacy.net/yacy_v1.924_20210209_10069.tar.gz" role="button">Download Yacy for Linux</a> from [https://download.yacy.net/yacy_v1.924_20210209_10069.tar.gz](https://download.yacy.net/yacy_v1.924_20210209_10069.tar.gz)
 * <a class="btn btn-success btn" href="https://download.yacy.net/yacy_v1.924_20201214_10042.dmg" role="button">Download YaCy for macOS</a> from [https://download.yacy.net/yacy_v1.924_20201214_10042.dmg](https://download.yacy.net/yacy_v1.924_20201214_10042.dmg)
+* <a class="btn btn-success btn" href="https://release.yacy.net/yacy_latest.tar.gz" role="button">Download latest developer release</A> for Linux from [https://release.yacy.net/](https://release.yacy.net/)
 
 ### With Docker
 


### PR DESCRIPTION
Because a official release wasn't made for a long time, and the only source of recent compiled version is https://release.yacy.net. So I added a "Download latest developer release" button to Download section. 